### PR TITLE
Fix typo in `pyproject.toml` for `httpx`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ tortoise-orm = {version = "^0.20.0", extras = ["asyncpg"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
-httpx = "^0.28.
+httpx = "^0.28.0"
 ruff = "^0.6.4"
 black = "^24.5.0"
 


### PR DESCRIPTION
This pull request addresses the following:

- Corrects a typographical error in the `pyproject.toml` file related to `httpx`.

No breaking changes are introduced. This is a minor fix to ensure proper functionality.